### PR TITLE
Add additional subscription properties

### DIFF
--- a/lib/gnat/streaming/subscription.ex
+++ b/lib/gnat/streaming/subscription.ex
@@ -12,6 +12,9 @@ defmodule Gnat.Streaming.Subscription do
             inbox: nil,
             max_in_flight: 100,
             queue_group: nil,
+            start_position: nil,
+            start_sequence: nil,
+            start_time_delta: nil,
             sub_subject: nil,
             subject: nil,
             task_supervisor_pid: nil
@@ -27,6 +30,10 @@ defmodule Gnat.Streaming.Subscription do
           inbox: String.t() | nil,
           max_in_flight: non_neg_integer(),
           queue_group: String.t() | nil,
+          start_position:
+            :first | :last_received | :new_only | :sequence_start | :time_delta_start | nil,
+          start_sequence: non_neg_integer | nil,
+          start_time_delta: integer | nil,
           sub_subject: String.t(),
           subject: String.t(),
           task_supervisor_pid: pid()
@@ -34,6 +41,7 @@ defmodule Gnat.Streaming.Subscription do
 
   require Logger
   alias Gnat.Streaming.{Client, Protocol}
+  alias Gnat.Streaming.Protocol.StartPosition
 
   def start_link(settings, options \\ []) do
     :gen_statem.start_link(__MODULE__, settings, options)
@@ -81,15 +89,29 @@ defmodule Gnat.Streaming.Subscription do
 
     durable_name = Keyword.get(settings, :durable_name)
     queue_group = Keyword.get(settings, :queue_group)
+    start_position = settings |> Keyword.get(:start_position) |> map_to_start_position_value()
+    start_sequence = Keyword.get(settings, :start_sequence)
+    start_time_delta = Keyword.get(settings, :start_time_delta)
+
     %__MODULE__{
       client_name: client_name,
       consuming_function: {mod, fun},
       durable_name: durable_name,
       queue_group: queue_group,
+      start_position: start_position,
+      start_sequence: start_sequence,
+      start_time_delta: start_time_delta,
       subject: subject,
       task_supervisor_pid: task_supervisor_pid
     }
   end
+
+  defp map_to_start_position_value(nil), do: nil
+  defp map_to_start_position_value(:first), do: StartPosition.value(:First)
+  defp map_to_start_position_value(:last_received), do: StartPosition.value(:LastReceived)
+  defp map_to_start_position_value(:new_only), do: StartPosition.value(:NewOnly)
+  defp map_to_start_position_value(:sequence_start), do: StartPosition.value(:SequenceStart)
+  defp map_to_start_position_value(:time_delta_start), do: StartPosition.value(:TimeDeltaStart)
 
   @doc false
   def disconnected(:internal, :connect, %__MODULE__{client_name: client_name}) do
@@ -142,6 +164,9 @@ defmodule Gnat.Streaming.Subscription do
         inbox: state.inbox,
         maxInFlight: state.max_in_flight,
         qGroup: state.queue_group,
+        startPosition: state.start_position,
+        startSequence: state.start_sequence,
+        startTimeDelta: state.start_time_delta,
         subject: state.subject
       )
       |> Protocol.SubscriptionRequest.encode()

--- a/lib/gnat/streaming/subscription.ex
+++ b/lib/gnat/streaming/subscription.ex
@@ -11,6 +11,7 @@ defmodule Gnat.Streaming.Subscription do
             durable_name: nil,
             inbox: nil,
             max_in_flight: 100,
+            queue_group: nil,
             sub_subject: nil,
             subject: nil,
             task_supervisor_pid: nil
@@ -25,6 +26,7 @@ defmodule Gnat.Streaming.Subscription do
           durable_name: String.t() | nil,
           inbox: String.t() | nil,
           max_in_flight: non_neg_integer(),
+          queue_group: String.t() | nil,
           sub_subject: String.t(),
           subject: String.t(),
           task_supervisor_pid: pid()
@@ -78,10 +80,12 @@ defmodule Gnat.Streaming.Subscription do
     subject = Keyword.fetch!(settings, :subject)
 
     durable_name = Keyword.get(settings, :durable_name)
+    queue_group = Keyword.get(settings, :queue_group)
     %__MODULE__{
       client_name: client_name,
       consuming_function: {mod, fun},
       durable_name: durable_name,
+      queue_group: queue_group,
       subject: subject,
       task_supervisor_pid: task_supervisor_pid
     }
@@ -137,6 +141,7 @@ defmodule Gnat.Streaming.Subscription do
         durableName: state.durable_name,
         inbox: state.inbox,
         maxInFlight: state.max_in_flight,
+        qGroup: state.queue_group,
         subject: state.subject
       )
       |> Protocol.SubscriptionRequest.encode()

--- a/lib/gnat/streaming/subscription.ex
+++ b/lib/gnat/streaming/subscription.ex
@@ -8,6 +8,7 @@ defmodule Gnat.Streaming.Subscription do
             client_name: nil,
             consuming_function: nil,
             connection_pid: nil,
+            durable_name: nil,
             inbox: nil,
             max_in_flight: 100,
             sub_subject: nil,
@@ -21,6 +22,7 @@ defmodule Gnat.Streaming.Subscription do
           client_name: atom(),
           consuming_function: {atom(), atom()},
           connection_pid: pid() | nil,
+          durable_name: String.t() | nil,
           inbox: String.t() | nil,
           max_in_flight: non_neg_integer(),
           sub_subject: String.t(),
@@ -75,9 +77,11 @@ defmodule Gnat.Streaming.Subscription do
     {mod, fun} = Keyword.fetch!(settings, :consuming_function)
     subject = Keyword.fetch!(settings, :subject)
 
+    durable_name = Keyword.get(settings, :durable_name)
     %__MODULE__{
       client_name: client_name,
       consuming_function: {mod, fun},
+      durable_name: durable_name,
       subject: subject,
       task_supervisor_pid: task_supervisor_pid
     }
@@ -130,6 +134,7 @@ defmodule Gnat.Streaming.Subscription do
       Protocol.SubscriptionRequest.new(
         ackWaitInSecs: state.ack_wait_in_sec,
         clientID: state.client_id,
+        durableName: state.durable_name,
         inbox: state.inbox,
         maxInFlight: state.max_in_flight,
         subject: state.subject


### PR DESCRIPTION
Add support to specify the following subscription properties:
- `queue_group`
- `durable_name`
- `start_position` (with all possible values)
- `start_sequence`
- `start_time_delta`

I added the necessary specs. But I could not figure out how to test those properly. I guess it would be best to add at least 2 more e2e tests. But at least the case of durable subscriptions needs disconnecting and creating a new subscription. And I could not figure out how to do it properly. If you could give me a hint, I am happy to add the test cases as well.